### PR TITLE
chore: standardize naming to "Logging operator"

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,10 +1,10 @@
 # Welcome to Kube Logging!
 
 Hello and welcome to Kube Logging!
-We are the proud maintainers of the [Logging Operator](https://github.com/kube-logging/logging-operator), a powerful open-source project dedicated to simplifying the complex world of logging on Kubernetes.
+We are the proud maintainers of the [Logging operator](https://github.com/kube-logging/logging-operator), a powerful open-source project dedicated to simplifying the complex world of logging on Kubernetes.
 
 Our main focus is to make logging on Kubernetes an accessible, understandable, and straightforward process for everyone, regardless of their skill level or experience.
-We believe in the power of community-driven development, and we are constantly inspired by the ways in which our community innovates and shapes the future of the Logging Operator.
+We believe in the power of community-driven development, and we are constantly inspired by the ways in which our community innovates and shapes the future of the Logging operator.
 
 ## Useful links
 
@@ -21,6 +21,6 @@ We believe in the power of community-driven development, and we are constantly i
 Whether you're a seasoned developer, a Kubernetes enthusiast, or someone just starting their journey in the cloud-native world, we invite you to join us.
 You can contribute by improving our code, enhancing our documentation, reporting or fixing bugs, or even just by sharing your experiences and insights.
 
-Explore our repositories, try out the Logging Operator, and give us your feedback. Together, we can make Kubernetes logging better for everyone!
+Explore our repositories, try out the Logging operator, and give us your feedback. Together, we can make Kubernetes logging better for everyone!
 
 **Happy logging!**


### PR DESCRIPTION
Followup https://github.com/kube-logging/logging-operator/issues/1986